### PR TITLE
update: populate fields of current struct on push & pull 

### DIFF
--- a/charybdis-macros/src/lib.rs
+++ b/charybdis-macros/src/lib.rs
@@ -164,10 +164,6 @@ pub fn charybdis_model(args: TokenStream, input: TokenStream) -> TokenStream {
         #delete_model_rule
     };
 
-    if struct_name == "Node" {
-        println!("{:#?}", expanded.to_string());
-    }
-
     TokenStream::from(expanded)
 }
 

--- a/charybdis-macros/src/lib.rs
+++ b/charybdis-macros/src/lib.rs
@@ -164,6 +164,10 @@ pub fn charybdis_model(args: TokenStream, input: TokenStream) -> TokenStream {
         #delete_model_rule
     };
 
+    if struct_name == "Node" {
+        println!("{:#?}", expanded.to_string());
+    }
+
     TokenStream::from(expanded)
 }
 

--- a/charybdis-macros/src/native/collection.rs
+++ b/charybdis-macros/src/native/collection.rs
@@ -5,7 +5,8 @@ use syn::parse_str;
 use charybdis_parser::fields::CharybdisFields;
 use charybdis_parser::traits::CharybdisMacroArgs;
 
-use crate::traits::fields::FieldsQuery;
+use crate::traits::fields::{CollectionStatements, FieldsQuery};
+use crate::traits::r#type::TypeWithoutOptions;
 use crate::traits::tuple::FieldsAsTuple;
 
 pub(crate) fn push_to_collection_consts(ch_args: &CharybdisMacroArgs, fields: &CharybdisFields) -> TokenStream {
@@ -169,12 +170,18 @@ pub(crate) fn push_to_collection_methods(fields: &CharybdisFields) -> TokenStrea
             let fun_name = parse_str::<TokenStream>(&fun_name_str).unwrap();
             let types = fields.primary_key_fields.types();
             let values = fields.primary_key_fields.values();
+            let field_type = field.ty.type_without_options();
+            let use_collection_statement = field.use_statement();
+            let extend_statement = field.extend_statement();
 
             let expanded = quote! {
-                pub fn #fun_name<V: charybdis::scylla::SerializeCql>(
-                    &self,
-                    value: V
-                ) -> charybdis::query::CharybdisQuery<(V, #(#types),*), Self, charybdis::query::ModelMutation> {
+                pub fn #fun_name(
+                    &mut self,
+                    value: #field_type,
+                ) -> charybdis::query::CharybdisQuery<(#field_type, #(#types),*), Self, charybdis::query::ModelMutation> {
+                    #use_collection_statement
+                    #extend_statement
+
                     charybdis::query::CharybdisQuery::new(
                         #push_to_query,
                         charybdis::query::QueryValue::Owned((value, #(#values),*)),
@@ -208,12 +215,18 @@ pub(crate) fn push_to_collection_methods_if_exists(fields: &CharybdisFields) -> 
             let fun_name = parse_str::<TokenStream>(&fun_name_str).unwrap();
             let types = fields.primary_key_fields.types();
             let values = fields.primary_key_fields.values();
+            let field_type = field.ty.type_without_options();
+            let use_collection_statement = field.use_statement();
+            let extend_statement = field.extend_statement();
 
             let expanded = quote! {
-                pub fn #fun_name<V: charybdis::scylla::SerializeCql>(
-                    &self,
-                    value: V
-                ) -> charybdis::query::CharybdisQuery<(V, #(#types),*), Self, charybdis::query::ModelMutation> {
+                pub fn #fun_name(
+                    &mut self,
+                    value: #field_type,
+                ) -> charybdis::query::CharybdisQuery<(#field_type, #(#types),*), Self, charybdis::query::ModelMutation> {
+                    #use_collection_statement
+                    #extend_statement
+
                     charybdis::query::CharybdisQuery::new(
                         #push_to_query,
                         charybdis::query::QueryValue::Owned((value, #(#values),*)),
@@ -247,12 +260,18 @@ pub(crate) fn pull_from_collection_methods(fields: &CharybdisFields) -> TokenStr
             let fun_name = parse_str::<TokenStream>(&fun_name_str).unwrap();
             let types = fields.primary_key_fields.types();
             let values = fields.primary_key_fields.values();
+            let field_type = field.ty.type_without_options();
+            let use_collection_statement = field.use_statement();
+            let remove_statement = field.remove_statement();
 
             let expanded = quote! {
-                pub fn #fun_name<V: charybdis::scylla::SerializeCql>(
+                pub fn #fun_name(
                     &self,
-                    value: V
-                ) -> charybdis::query::CharybdisQuery<(V, #(#types),*), Self, charybdis::query::ModelMutation> {
+                    value: #field_type,
+                ) -> charybdis::query::CharybdisQuery<(#field_type, #(#types),*), Self, charybdis::query::ModelMutation> {
+                    #use_collection_statement
+                    #remove_statement
+
                     charybdis::query::CharybdisQuery::new(
                         #pull_from_query,
                         charybdis::query::QueryValue::Owned((value, #(#values),*)),
@@ -286,12 +305,18 @@ pub(crate) fn pull_from_collection_methods_if_exists(fields: &CharybdisFields) -
             let fun_name = parse_str::<TokenStream>(&fun_name_str).unwrap();
             let types = fields.primary_key_fields.types();
             let values = fields.primary_key_fields.values();
+            let field_type = field.ty.type_without_options();
+            let use_collection_statement = field.use_statement();
+            let remove_statement = field.remove_statement();
 
             let expanded = quote! {
-                pub fn #fun_name<V: charybdis::scylla::SerializeCql>(
+                pub fn #fun_name(
                     &self,
-                    value: V
-                ) -> charybdis::query::CharybdisQuery<(V, #(#types),*), Self, charybdis::query::ModelMutation> {
+                    value: #field_type,
+                ) -> charybdis::query::CharybdisQuery<(#field_type, #(#types),*), Self, charybdis::query::ModelMutation> {
+                    #use_collection_statement
+                    #remove_statement
+
                     charybdis::query::CharybdisQuery::new(
                         #pull_from_query,
                         charybdis::query::QueryValue::Owned((value, #(#values),*)),

--- a/charybdis-macros/src/traits/fields.rs
+++ b/charybdis-macros/src/traits/fields.rs
@@ -2,7 +2,9 @@ pub(crate) use arguments::*;
 use charybdis_parser::fields::Field;
 pub(crate) use find::*;
 pub(crate) use hash_map::*;
+use proc_macro2::TokenStream;
 pub(crate) use query::*;
+use quote::quote;
 
 mod arguments;
 mod find;
@@ -29,5 +31,75 @@ pub(crate) trait FieldsNames {
 impl FieldsNames for Vec<&Field<'_>> {
     fn names(&self) -> Vec<String> {
         self.iter().map(|field| field.name.clone()).collect()
+    }
+}
+
+pub(crate) trait CollectionStatements {
+    fn use_statement(&self) -> TokenStream;
+    fn new_collection(&self) -> TokenStream;
+    fn extend_statement(&self) -> TokenStream;
+    fn remove_statement(&self) -> TokenStream;
+}
+
+impl CollectionStatements for Field<'_> {
+    fn use_statement(&self) -> TokenStream {
+        if self.is_list() {
+            quote! { use std::vec::Vec; }
+        } else if self.is_map() {
+            quote! { use std::collections::HashMap; }
+        } else if self.is_set() {
+            quote! { use std::collections::HashSet; }
+        } else {
+            panic!("Not a collection type");
+        }
+    }
+
+    fn new_collection(&self) -> TokenStream {
+        if self.is_list() {
+            quote! { Vec::new() }
+        } else if self.is_map() {
+            quote! { HashMap::new() }
+        } else if self.is_set() {
+            quote! { HashSet::new() }
+        } else {
+            panic!("Not a collection type");
+        }
+    }
+
+    fn extend_statement(&self) -> TokenStream {
+        let field_name = &self.ident;
+        let new_collection = self.new_collection();
+
+        return if self.is_option {
+            quote! {
+                self.#field_name.get_or_insert_with(#new_collection).extend(value);
+            }
+        } else {
+            quote! {
+                self.#field_name.extend(value);
+            }
+        };
+    }
+
+    fn remove_statement(&self) -> TokenStream {
+        let field_name = &self.ident;
+        let new_collection = self.new_collection();
+        let field = quote! {
+            self.#field_name.get_or_insert_with(#new_collection)
+        };
+
+        if self.is_list() || self.is_set() {
+            quote! {
+                #field.retain(|item| !value.contains(item));
+            }
+        } else if self.is_map() {
+            quote! {
+                value.iter().for_each(|(key, _)| {
+                    #field.remove(key);
+                });
+            }
+        } else {
+            panic!("Not a collection type");
+        }
     }
 }

--- a/charybdis-parser/src/fields.rs
+++ b/charybdis-parser/src/fields.rs
@@ -4,6 +4,7 @@ use darling::FromAttributes;
 use syn::spanned::Spanned;
 use syn::{Data, DeriveInput, Fields, FieldsNamed, GenericArgument, PathArguments, Type};
 
+use crate::traits::syn_field::IsOption;
 use crate::traits::CharybdisMacroArgs;
 
 #[derive(Clone, PartialEq, strum_macros::Display, strum_macros::EnumString)]
@@ -58,6 +59,7 @@ pub struct Field<'a> {
     pub is_partition_key: bool,
     pub is_clustering_key: bool,
     pub is_static_column: bool,
+    pub is_option: bool,
 }
 
 impl<'a> Field<'a> {
@@ -124,6 +126,7 @@ impl<'a> Field<'a> {
                     is_partition_key,
                     is_clustering_key,
                     is_static_column,
+                    is_option: field.is_option(),
                 };
             })
             .unwrap()

--- a/charybdis-parser/src/traits.rs
+++ b/charybdis-parser/src/traits.rs
@@ -10,6 +10,7 @@ use crate::traits::hash::hash_expr_lit_to_hash;
 mod array;
 mod hash;
 pub mod string;
+pub(crate) mod syn_field;
 
 static EMPTY_VEC: Vec<String> = Vec::new();
 

--- a/charybdis-parser/src/traits/syn_field.rs
+++ b/charybdis-parser/src/traits/syn_field.rs
@@ -1,0 +1,20 @@
+use syn::{Field, PathArguments, Type};
+
+pub trait IsOption {
+    fn is_option(&self) -> bool;
+}
+
+impl IsOption for Field {
+    fn is_option(&self) -> bool {
+        if let Type::Path(type_path) = &self.ty {
+            if let Some(last_segment) = type_path.path.segments.last() {
+                return last_segment.ident == "Option"
+                    && matches!(
+                        last_segment.arguments,
+                        PathArguments::AngleBracketed(ref args) if !args.args.is_empty()
+                    );
+            }
+        }
+        false
+    }
+}


### PR DESCRIPTION
Currently, when we do `model.push_<collection_field>(val)` we just run db query, but we don't alter model fields themselves. This change should make sure that model fields are changed on app level as well.
