### PR TITLE
update: DRY-up migration builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,25 +212,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "charybdis"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d31b41707fdc6743ce011610b10cc9557970c1bd59cf8c63fd5ddb0c8e60a39"
-dependencies = [
- "bigdecimal",
- "charybdis_macros 0.7.0",
- "chrono",
- "colored",
- "futures",
- "num-bigint 0.4.4",
- "scylla",
- "serde",
- "serde_json",
- "uuid",
-]
-
-[[package]]
-name = "charybdis"
 version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b2a25dc45c6f68710903d18635ddd348a6b67ada9cd9c9a8f36bb2d242d129a"
 dependencies = [
  "bigdecimal",
  "charybdis_macros 0.7.2",
@@ -245,10 +229,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "charybdis-migrate"
-version = "0.7.4"
+name = "charybdis"
+version = "0.7.5"
 dependencies = [
- "charybdis_parser 0.7.2",
+ "bigdecimal",
+ "charybdis_macros 0.7.5",
+ "chrono",
+ "colored",
+ "futures",
+ "num-bigint 0.4.4",
+ "scylla",
+ "serde",
+ "serde_json",
+ "uuid",
+]
+
+[[package]]
+name = "charybdis-migrate"
+version = "0.7.5"
+dependencies = [
+ "charybdis_parser 0.7.5",
  "clap",
  "colored",
  "openssl",
@@ -262,11 +262,11 @@ dependencies = [
 
 [[package]]
 name = "charybdis_macros"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5eeed3f4b08b938ea6d234b5f177922f43c968f23a263fdb3abfc7a42bf9d8c"
+checksum = "22275746377c3263a9154d22c19a08498e8bcf511407175cb20bc3de8b055646"
 dependencies = [
- "charybdis_parser 0.7.0",
+ "charybdis_parser 0.7.2",
  "darling",
  "proc-macro2",
  "quote",
@@ -275,10 +275,10 @@ dependencies = [
 
 [[package]]
 name = "charybdis_macros"
-version = "0.7.2"
+version = "0.7.5"
 dependencies = [
- "charybdis 0.7.1",
- "charybdis_parser 0.7.2",
+ "charybdis 0.7.2",
+ "charybdis_parser 0.7.5",
  "darling",
  "proc-macro2",
  "quote",
@@ -288,9 +288,9 @@ dependencies = [
 
 [[package]]
 name = "charybdis_parser"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d3097e420e990489804ecc072c97d3e71fe6ff6623cc3a305e76cf5cfdfe7ec"
+checksum = "80a6cb30fe0040056e65e175ce03ac7e9d9ffde308ba95ced1be938bbb170dbb"
 dependencies = [
  "colored",
  "darling",
@@ -307,7 +307,7 @@ dependencies = [
 
 [[package]]
 name = "charybdis_parser"
-version = "0.7.2"
+version = "0.7.5"
 dependencies = [
  "colored",
  "darling",

--- a/charybdis-macros/Cargo.toml
+++ b/charybdis-macros/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "charybdis_macros"
 rust-version = "1.75.0"
-version = "0.7.2"
+version = "0.7.5"
 edition = "2021"
 description = "Proc macro crate for Charybdis ORM"
 repository = "https://github.com/nodecosmos/charybdis"
@@ -12,12 +12,12 @@ categories = ["database"]
 proc-macro = true
 
 [dependencies]
-charybdis_parser = { version = "0.7.2", path = "../charybdis-parser" }
+charybdis_parser = { version = "0.7.5", path = "../charybdis-parser" }
 proc-macro2 = "1.0.81"
 syn = { version = "2.0.60", features = ["full"] }
 quote = "1.0.36"
 darling = "0.20.8"
 
 [dev-dependencies]
-charybdis = "0.7.1"
+charybdis = "0.7.2"
 scylla = "0.13.1"

--- a/charybdis-migrate/Cargo.toml
+++ b/charybdis-migrate/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "charybdis-migrate"
 rust-version = "1.75.0"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "Automatic Migration Tool for Charybdis ORM"
 repository = "https://github.com/nodecosmos/charybdis"
@@ -9,14 +9,14 @@ license = "MIT"
 categories = ["database"]
 
 [dependencies]
-charybdis_parser = { version = "0.7.2", path = "../charybdis-parser" }
+charybdis_parser = { version = "0.7.5", path = "../charybdis-parser" }
 scylla = { version = "0.13.1", features = ["ssl"] }
 tokio = { version = "1.38.0", features = ["full"] }
 serde_json = "1.0.120"
 serde = { version = "1.0.204", features = ["derive"] }
 colored = "2.1.0"
 strip-ansi-escapes = "0.2.0"
-clap = { version = "4.5.9", features = ["derive"] }
+clap = { version = "4.5.9", features = ["derive", "string"] }
 regex = "1.10.5"
 openssl = "0.10.64"
 

--- a/charybdis-migrate/src/lib.rs
+++ b/charybdis-migrate/src/lib.rs
@@ -1,124 +1,88 @@
-use std::path::PathBuf;
-use scylla::Session;
-use charybdis_parser::schema::code_schema::CodeSchema;
-use charybdis_parser::schema::db_schema::DbSchema;
 use crate::args::Args;
 use crate::migration::Migration;
 use crate::session::initialize_session;
+use charybdis_parser::schema::code_schema::CodeSchema;
+use charybdis_parser::schema::db_schema::DbSchema;
+use scylla::Session;
 
+pub mod args;
 pub mod migration;
 pub mod model;
 pub mod session;
-pub mod args;
 
 pub struct MigrationBuilder {
-    pub host: String,
-    pub keyspace: String,
-    pub user: Option<String>,
-    pub password: Option<String>,
-    pub timeout: u64,
-    pub drop_and_replace: bool,
-    pub verbose: bool,
-    pub ca: Option<String>,
-    pub cert: Option<String>,
-    pub key: Option<String>,
+    pub(crate) args: Args,
 }
 
 impl MigrationBuilder {
     pub fn new() -> Self {
-        MigrationBuilder {
-            host: String::new(),
-            keyspace: String::new(),
-            user: None,
-            password: None,
-            timeout: 30,
-            drop_and_replace: false,
-            verbose: false,
-            ca: None,
-            cert: None,
-            key: None,
-        }
+        Self { args: Args::default() }
+    }
+
+    pub async fn build(self) -> Migration {
+        let session: Session = initialize_session(&self.args).await;
+        let current_db_schema = DbSchema::new(&session, self.args.keyspace.clone()).await;
+        let current_code_schema = CodeSchema::new(&self.args.project_root);
+
+        let migration = Migration::new(current_db_schema, current_code_schema, session, self.args);
+
+        migration
     }
 
     pub fn host(mut self, host: &str) -> Self {
-        self.host = host.to_string();
+        self.args.host = host.to_string();
         self
     }
 
     pub fn keyspace(mut self, keyspace: &str) -> Self {
-        self.keyspace = keyspace.to_string();
+        self.args.keyspace = keyspace.to_string();
         self
     }
 
     pub fn user(mut self, user: Option<&str>) -> Self {
-        self.user = user.map(|s| s.to_string());
+        self.args.user = user.map(|s| s.to_string());
         self
     }
 
     pub fn password(mut self, password: Option<&str>) -> Self {
-        self.password = password.map(|s| s.to_string());
+        self.args.password = password.map(|s| s.to_string());
         self
     }
 
     pub fn timeout(mut self, timeout: u64) -> Self {
-        self.timeout = timeout;
+        self.args.timeout = timeout;
         self
     }
 
     pub fn drop_and_replace(mut self, drop_and_replace: bool) -> Self {
-        self.drop_and_replace = drop_and_replace;
+        self.args.drop_and_replace = drop_and_replace;
         self
     }
 
     pub fn verbose(mut self, verbose: bool) -> Self {
-        self.verbose = verbose;
+        self.args.verbose = verbose;
         self
     }
 
     pub fn ca(mut self, ca: Option<&str>) -> Self {
-        self.ca = ca.map(|s| s.to_string());
+        self.args.ca = ca.map(|s| s.to_string());
         self
     }
 
     pub fn cert(mut self, cert: Option<&str>) -> Self {
-        self.cert = cert.map(|s| s.to_string());
+        self.args.cert = cert.map(|s| s.to_string());
         self
     }
 
     pub fn key(mut self, key: Option<&str>) -> Self {
-        self.key = key.map(|s| s.to_string());
+        self.args.key = key.map(|s| s.to_string());
         self
     }
+}
 
-    pub fn from_args(args: Args) -> Self {
-        Self {
-            host: args.host,
-            keyspace: args.keyspace,
-            user: args.user,
-            password: args.password,
-            timeout: args.timeout,
-            drop_and_replace: args.drop_and_replace,
-            verbose: args.verbose,
-            ca: args.ca,
-            cert: args.cert,
-            key: args.key,
-        }
-    }
-
-    pub async fn run(self, project_root: &PathBuf) {
-        let session: Session = initialize_session(&self).await;
-
-        self.run_with_session(&session, project_root).await;
-    }
-
-    /// Run migration with provided session
-    pub async fn run_with_session(self, session: &Session, project_root: &PathBuf) {
-        let current_db_schema = DbSchema::new(session, self.keyspace.clone()).await;
-        let current_code_schema = CodeSchema::new(project_root);
-
-        let migration = Migration::new(&current_db_schema, &current_code_schema, session, &self);
-
-        migration.run().await;
+impl From<Args> for MigrationBuilder {
+    fn from(args: Args) -> Self {
+        Self { args }
     }
 }
 

--- a/charybdis-migrate/src/migrate.rs
+++ b/charybdis-migrate/src/migrate.rs
@@ -1,6 +1,8 @@
 use clap::Parser;
 use migrate::args::Args;
+use migrate::session::initialize_session;
 use migrate::MigrationBuilder;
+use scylla::Session;
 use std::env;
 
 /// Automatic Migration Tool
@@ -11,7 +13,8 @@ async fn main() {
     }
 
     let args = Args::parse();
-    let migration = MigrationBuilder::from(args).build().await;
+    let session: Session = initialize_session(&args).await;
+    let migration = MigrationBuilder::from(args).build(&session).await;
 
     migration.run().await;
     migration.write_schema_to_json().await;

--- a/charybdis-migrate/src/migrate.rs
+++ b/charybdis-migrate/src/migrate.rs
@@ -1,48 +1,18 @@
-use std::fs::read_dir;
-use std::io::ErrorKind;
-use std::path::PathBuf;
-use std::{env, io};
-
 use clap::Parser;
-use scylla::Session;
-use charybdis_parser::schema::db_schema::DbSchema;
 use migrate::args::Args;
 use migrate::MigrationBuilder;
-use migrate::session::initialize_session;
+use std::env;
 
 /// Automatic Migration Tool
 #[tokio::main]
 async fn main() {
-    let args = Args::parse();
-    let project_root = get_project_root().unwrap();
-    let migration_data = MigrationBuilder::from_args(args);
-    let keyspace = migration_data.keyspace.clone();
-    let session: Session = initialize_session(&migration_data).await;
-
     if env::var("FORCE_COLOR").is_ok() {
         colored::control::set_override(true);
     }
 
-    migration_data.run_with_session(&session, &project_root).await;
+    let args = Args::parse();
+    let migration = MigrationBuilder::from(args).build().await;
 
-    DbSchema::new(&session, keyspace)
-        .await
-        .write_schema_to_json(project_root);
-}
-
-pub(crate) fn get_project_root() -> io::Result<PathBuf> {
-    let path = env::current_dir()?;
-    let path_ancestors = path.as_path().ancestors();
-
-    for p in path_ancestors {
-        let has_cargo = read_dir(p)?.any(|p| p.unwrap().file_name() == *"Cargo.lock");
-        if has_cargo {
-            return Ok(PathBuf::from(p));
-        }
-    }
-
-    Err(io::Error::new(
-        ErrorKind::NotFound,
-        "Ran out of places to find Cargo.toml",
-    ))
+    migration.run().await;
+    migration.write_schema_to_json().await;
 }

--- a/charybdis-migrate/src/migration.rs
+++ b/charybdis-migrate/src/migration.rs
@@ -1,33 +1,28 @@
 use colored::Colorize;
 use scylla::Session;
 
+use crate::args::Args;
+use crate::model::data::ModelData;
+use crate::model::{ModelMigration, ModelType};
+
 use charybdis_parser::schema::code_schema::CodeSchema;
 use charybdis_parser::schema::db_schema::DbSchema;
 use charybdis_parser::schema::SchemaObject;
-use crate::MigrationBuilder;
 
-use crate::model::{ModelMigration, ModelType};
-use crate::model::data::ModelData;
-
-pub struct Migration<'a> {
-    current_db_schema: &'a DbSchema,
-    current_code_schema: &'a CodeSchema,
-    session: &'a Session,
-    migration_data: &'a MigrationBuilder,
+pub struct Migration {
+    current_db_schema: DbSchema,
+    current_code_schema: CodeSchema,
+    session: Session,
+    args: Args,
 }
 
-impl<'a> Migration<'a> {
-    pub fn new(
-        current_db_schema: &'a DbSchema,
-        current_code_schema: &'a CodeSchema,
-        session: &'a Session,
-        migration_data: &'a MigrationBuilder,
-    ) -> Self {
+impl Migration {
+    pub fn new(current_db_schema: DbSchema, current_code_schema: CodeSchema, session: Session, args: Args) -> Self {
         Migration {
             current_db_schema,
             current_code_schema,
             session,
-            migration_data,
+            args,
         }
     }
 
@@ -37,6 +32,12 @@ impl<'a> Migration<'a> {
         self.run_materialized_views().await;
 
         println!("\n{}", "Migration plan ran successfully!".bright_green());
+    }
+
+    pub async fn write_schema_to_json(&self) {
+        DbSchema::new(&self.session, self.args.keyspace.clone())
+            .await
+            .write_schema_to_json(&self.args.project_root);
     }
 
     async fn run_udts(&self) {
@@ -50,7 +51,7 @@ impl<'a> Migration<'a> {
                 self.current_db_schema.udts.get(name).unwrap_or(&empty_udt),
             );
 
-            let migration = ModelMigration::new(&model_data, self.session, self.migration_data);
+            let migration = ModelMigration::new(&model_data, &self.session, &self.args);
 
             migration.run().await;
         }
@@ -67,7 +68,7 @@ impl<'a> Migration<'a> {
                 self.current_db_schema.tables.get(name).unwrap_or(&empty_table),
             );
 
-            let migration = ModelMigration::new(&model_data, self.session, self.migration_data);
+            let migration = ModelMigration::new(&model_data, &self.session, &self.args);
 
             migration.run().await;
         }
@@ -84,7 +85,7 @@ impl<'a> Migration<'a> {
                 self.current_db_schema.materialized_views.get(name).unwrap_or(&empty_mv),
             );
 
-            let migration = ModelMigration::new(&model_data, self.session, self.migration_data);
+            let migration = ModelMigration::new(&model_data, &self.session, &self.args);
 
             migration.run().await;
         }

--- a/charybdis-migrate/src/migration.rs
+++ b/charybdis-migrate/src/migration.rs
@@ -9,15 +9,15 @@ use charybdis_parser::schema::code_schema::CodeSchema;
 use charybdis_parser::schema::db_schema::DbSchema;
 use charybdis_parser::schema::SchemaObject;
 
-pub struct Migration {
+pub struct Migration<'a> {
     current_db_schema: DbSchema,
     current_code_schema: CodeSchema,
-    session: Session,
+    session: &'a Session,
     args: Args,
 }
 
-impl Migration {
-    pub fn new(current_db_schema: DbSchema, current_code_schema: CodeSchema, session: Session, args: Args) -> Self {
+impl<'a> Migration<'a> {
+    pub fn new(current_db_schema: DbSchema, current_code_schema: CodeSchema, session: &'a Session, args: Args) -> Self {
         Migration {
             current_db_schema,
             current_code_schema,

--- a/charybdis-migrate/src/model.rs
+++ b/charybdis-migrate/src/model.rs
@@ -1,8 +1,8 @@
 use std::fmt::Display;
 
+use crate::args::Args;
 use colored::Colorize;
 use scylla::Session;
-use crate::MigrationBuilder;
 
 use crate::model::data::ModelData;
 use crate::model::runner::ModelRunner;
@@ -57,14 +57,14 @@ impl MigrationStep {
 pub(crate) struct ModelMigration<'a> {
     data: &'a ModelData<'a>,
     runner: ModelRunner<'a>,
-    migration_data: &'a MigrationBuilder,
+    args: &'a Args,
 }
 
 impl<'a> ModelMigration<'a> {
-    pub(crate) fn new(data: &'a ModelData, session: &'a Session, migration_data: &'a MigrationBuilder) -> Self {
-        let runner = ModelRunner::new(session, data, migration_data);
+    pub(crate) fn new(data: &'a ModelData, session: &'a Session, args: &'a Args) -> Self {
+        let runner = ModelRunner::new(session, data, args);
 
-        Self { data, runner, migration_data }
+        Self { data, runner, args }
     }
 
     pub(crate) async fn run(&self) {
@@ -149,7 +149,7 @@ impl<'a> ModelMigration<'a> {
     }
 
     async fn handle_fields_type_change(&self) {
-        if self.migration_data.drop_and_replace {
+        if self.args.drop_and_replace {
             self.panic_on_mv_fields_change();
             self.panic_on_udt_fields_removal();
 

--- a/charybdis-migrate/src/model/runner.rs
+++ b/charybdis-migrate/src/model/runner.rs
@@ -1,20 +1,19 @@
+use crate::args::Args;
+use crate::model::{ModelData, ModelType};
 use colored::*;
 use regex::Regex;
 use scylla::Session;
-use crate::MigrationBuilder;
-
-use crate::model::{ModelData, ModelType};
 
 pub(crate) const INDEX_SUFFIX: &str = "idx";
 
 pub(crate) struct ModelRunner<'a> {
     session: &'a Session,
     data: &'a ModelData<'a>,
-    args: &'a MigrationBuilder,
+    args: &'a Args,
 }
 
 impl<'a> ModelRunner<'a> {
-    pub fn new(session: &'a Session, data: &'a ModelData, args: &'a MigrationBuilder) -> Self {
+    pub fn new(session: &'a Session, data: &'a ModelData, args: &'a Args) -> Self {
         Self { session, data, args }
     }
 
@@ -192,9 +191,7 @@ impl<'a> ModelRunner<'a> {
 
         let cql = format!(
             "ALTER {} {} DROP ({})",
-            self.data.migration_object_type,
-            self.data.migration_object_name,
-            removed_fields,
+            self.data.migration_object_type, self.data.migration_object_name, removed_fields,
         );
 
         self.execute(&cql, true).await;
@@ -219,9 +216,7 @@ impl<'a> ModelRunner<'a> {
 
         let cql = format!(
             "ALTER {} {} DROP ({})",
-            self.data.migration_object_type,
-            self.data.migration_object_name,
-            changed_fields,
+            self.data.migration_object_type, self.data.migration_object_name, changed_fields,
         );
 
         self.execute(&cql, true).await;

--- a/charybdis-migrate/src/session.rs
+++ b/charybdis-migrate/src/session.rs
@@ -1,10 +1,10 @@
 use std::time::Duration;
 
+use crate::args::Args;
 use openssl::ssl::{SslContextBuilder, SslMethod, SslVerifyMode};
 use scylla::{Session, SessionBuilder};
-use crate::MigrationBuilder;
 
-pub async fn initialize_session(args: &MigrationBuilder) -> Session {
+pub async fn initialize_session(args: &Args) -> Session {
     let mut builder = SessionBuilder::new()
         .known_node(&args.host)
         .use_keyspace(&args.keyspace, false)

--- a/charybdis-parser/Cargo.toml
+++ b/charybdis-parser/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "charybdis_parser"
 rust-version = "1.75.0"
-version = "0.7.2"
+version = "0.7.5"
 edition = "2021"
 description = "Parser crate for Charybdis ORM"
 repository = "https://github.com/nodecosmos/charybdis"

--- a/charybdis-parser/src/schema/code_schema.rs
+++ b/charybdis-parser/src/schema/code_schema.rs
@@ -34,7 +34,7 @@ pub struct CodeSchema {
 }
 
 impl CodeSchema {
-    pub fn new(project_root: &PathBuf) -> CodeSchema {
+    pub fn new(project_root: &String) -> CodeSchema {
         let mut current_code_schema = CodeSchema {
             tables: SchemaObjects::new(),
             udts: SchemaObjects::new(),
@@ -46,7 +46,8 @@ impl CodeSchema {
         current_code_schema
     }
 
-    pub fn get_models_from_code(&mut self, project_root: &PathBuf) {
+    pub fn get_models_from_code(&mut self, project_root: &String) {
+        let project_root: PathBuf = PathBuf::from(project_root);
         for entry in WalkDir::new(project_root) {
             let entry: DirEntry = entry.unwrap();
 

--- a/charybdis-parser/src/schema/db_schema.rs
+++ b/charybdis-parser/src/schema/db_schema.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::path::PathBuf;
 
 use colored::Colorize;
 use scylla::Session;
@@ -7,8 +6,8 @@ use serde::{Deserialize, Serialize};
 use serde_json::to_string_pretty;
 
 use crate::errors::DbSchemaParserError;
-use crate::schema::{SchemaObject, SchemaObjects};
 use crate::schema::secondary_indexes::{IndexTarget, SecondaryIndex};
+use crate::schema::{SchemaObject, SchemaObjects};
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DbSchema {
@@ -345,10 +344,10 @@ impl DbSchema {
         })
     }
 
-    pub fn write_schema_to_json(&self, project_root: PathBuf) {
+    pub fn write_schema_to_json(&self, project_root: &str) {
         let json = self.get_current_schema_as_json();
 
-        let path = project_root.to_str().unwrap().to_string() + "/current_schema.json";
+        let path = project_root.to_string() + "/current_schema.json";
 
         std::fs::write(path, json).unwrap_or_else(|e| {
             panic!("Error writing schema to json: {}", e);

--- a/charybdis/Cargo.toml
+++ b/charybdis/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "charybdis"
 rust-version = "1.75.0"
-version = "0.7.2"
+version = "0.7.5"
 edition = "2021"
 description = "High-Performance ORM for ScyllaDB"
 repository = "https://github.com/nodecosmos/charybdis"
@@ -11,7 +11,7 @@ categories = ["database"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-charybdis_macros = { version = "0.7.2", path = "../charybdis-macros" }
+charybdis_macros = { version = "0.7.5", path = "../charybdis-macros" }
 chrono = { version = "0.4.38", features = ["serde"] }
 futures = "0.3.30"
 num-bigint = "0.4.4"


### PR DESCRIPTION
- use single Args structure 
- 'MigrationBuilder' accepts only migration-relevant options
- `MigrationBuilder` build() now returns `Migration` obj that we can use to run migrations