### PR TITLE
Added project_root option in MigrationBuilder

### DIFF
--- a/charybdis-migrate/src/lib.rs
+++ b/charybdis-migrate/src/lib.rs
@@ -40,6 +40,11 @@ impl MigrationBuilder {
         self
     }
 
+    pub fn project_root(mut self, project_root: String) -> Self {
+        self.args.keyspace = project_root;
+        self
+    }
+
     pub fn drop_and_replace(mut self, drop_and_replace: bool) -> Self {
         self.args.drop_and_replace = drop_and_replace;
         self


### PR DESCRIPTION
I want to add the `project_root` option to the MigrationBuilder to omit searching the entire project (this is also a temporary solution to #49 )