### PR TITLE
fix: add escape characters to column names

### DIFF
--- a/charybdis-macros/src/scylla/from_row.rs
+++ b/charybdis-macros/src/scylla/from_row.rs
@@ -36,6 +36,7 @@ pub(crate) fn from_row(struct_name: &syn::Ident, fields: &CharybdisFields) -> Im
     });
 
     let generated = quote! {
+        #[allow(clippy::unwrap_used, clippy::unwrap_in_result)]
         fn from_row(row: charybdis::scylla::Row) -> ::std::result::Result<Self, charybdis::scylla::FromRowError> {
                 use ::std::result::Result::{Ok, Err};
                 use ::std::iter::{Iterator, IntoIterator};

--- a/charybdis-macros/src/traits/fields/query.rs
+++ b/charybdis-macros/src/traits/fields/query.rs
@@ -12,13 +12,17 @@ pub(crate) trait FieldsQuery {
 
 impl FieldsQuery for Vec<&Field<'_>> {
     fn comma_sep_cols(&self) -> String {
-        self.names().join(", ")
+        self.names()
+            .iter()
+            .map(|s| format!(r#""{s}""#))
+            .collect::<Vec<String>>()
+            .join(", ")
     }
 
     fn insert_bind_markers(&self) -> String {
         let str_vec = self
             .iter()
-            .map(|field| format!(":{}", field.name))
+            .map(|field| format!(r#":"{}""#, field.name))
             .collect::<Vec<String>>()
             .join(", ");
 

--- a/charybdis/src/query.rs
+++ b/charybdis/src/query.rs
@@ -9,7 +9,7 @@ use crate::options::{Consistency, ExecutionProfileHandle, HistoryListener, Retry
 use crate::stream::CharybdisModelStream;
 use scylla::query::Query;
 use scylla::serialize::row::{RowSerializationContext, SerializeRow};
-use scylla::serialize::{RowWriter, SerializationError};
+use scylla::serialize::{writers::RowWriter, SerializationError};
 use scylla::statement::{PagingState, PagingStateResponse};
 use scylla::transport::query_result::FirstRowTypedError;
 use scylla::{CachingSession, IntoTypedRows, QueryResult};


### PR DESCRIPTION
## Description 

This PR adds escape characters to every column name so if there's any reserved keyword in the column name that will be ignored.