### PR TITLE
feat: Add migrate as default feature of charybdis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -233,6 +233,7 @@ name = "charybdis"
 version = "0.7.9"
 dependencies = [
  "bigdecimal",
+ "charybdis-migrate",
  "charybdis_macros 0.7.9",
  "chrono",
  "colored",

--- a/charybdis/Cargo.toml
+++ b/charybdis/Cargo.toml
@@ -23,5 +23,4 @@ colored = "2.1.0"
 bigdecimal = { version = "0.4.3", features = ["serde"] }
 
 [features]
-default = ["migrate"]
 migrate = ["charybdis-migrate"]

--- a/charybdis/Cargo.toml
+++ b/charybdis/Cargo.toml
@@ -11,6 +11,7 @@ categories = ["database"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+charybdis-migrate = { version = "0.7.9", path = "../charybdis-migrate", optional = true }
 charybdis_macros = { version = "0.7.9", path = "../charybdis-macros" }
 chrono = { version = "0.4.38", features = ["serde"] }
 futures = "0.3.30"
@@ -20,3 +21,7 @@ serde_json = "1.0.116"
 serde = { version = "1.0.200", features = ["derive"] }
 colored = "2.1.0"
 bigdecimal = { version = "0.4.3", features = ["serde"] }
+
+[features]
+default = ["migrate"]
+migrate = ["charybdis-migrate"]

--- a/charybdis/README.md
+++ b/charybdis/README.md
@@ -207,7 +207,7 @@ Resulting auto-generated migration query will be:
 * ### Programmatically running migrations
   Within testing or development environment, we can trigger migrations programmatically:
     ```rust
-    use charybdis_migrate::MigrationBuilder;
+    use charybdis::migrate::MigrationBuilder;
     
     let migration = MigrationBuilder::new()
         .keyspace("test")

--- a/charybdis/src/lib.rs
+++ b/charybdis/src/lib.rs
@@ -11,6 +11,9 @@ pub mod serializers;
 pub mod stream;
 pub mod types;
 
+#[cfg(feature = "migrate")]
+pub use migrate;
+
 pub mod macros {
     pub use charybdis_macros::{
         char_model_field_attrs_gen, charybdis_model, charybdis_udt_model, charybdis_view_model,


### PR DESCRIPTION
Makes the `migrate` lib a default feature of the core `charybdis` lib and adds a public re-export.

Closes #61 

