### PR TITLE
override column type using macro attribute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -223,6 +223,7 @@ dependencies = [
  "scylla",
  "serde",
  "serde_json",
+ "strum",
  "tokio",
  "uuid",
 ]
@@ -362,7 +363,7 @@ version = "4.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2bac35c6dafb060fd4d275d9a4ffae97917c13a6327903a8be2153cd964f7085"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -595,12 +596,6 @@ dependencies = [
  "ahash",
  "allocator-api2",
 ]
-
-[[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
 
 [[package]]
 name = "heck"
@@ -1190,17 +1185,20 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.2"
+version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d8cec3501a5194c432b2b7976db6b7d10ec95c253208b45f83f7136aa985e29"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6cf59daf282c0a494ba14fd21610a0325f9f90ec9d1231dea26bcb1d696c946"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
 dependencies = [
- "heck 0.4.1",
+ "heck",
  "proc-macro2",
  "quote",
  "rustversion",

--- a/charybdis-macros/src/lib.rs
+++ b/charybdis-macros/src/lib.rs
@@ -230,7 +230,10 @@ pub fn charybdis_view_model(args: TokenStream, input: TokenStream) -> TokenStrea
 
 #[proc_macro_attribute]
 pub fn charybdis_udt_model(_: TokenStream, input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as DeriveInput);
+    let mut input = parse_macro_input!(input as DeriveInput);
+
+    CharybdisFields::proxy_charybdis_attrs_to_scylla(&mut input);
+    CharybdisFields::strip_charybdis_attributes(&mut input);
 
     let gen = quote! {
         #[derive(charybdis::macros::scylla::SerializeValue)]

--- a/charybdis-parser/src/schema/code_schema/parser.rs
+++ b/charybdis-parser/src/schema/code_schema/parser.rs
@@ -101,7 +101,7 @@ fn extract_schema_object(item_struct: &ItemStruct, model_macro: &ModelMacro) -> 
 
         for field in db_fields {
             let field_name = field.ident.to_string();
-            let field_type = type_with_arguments(&field.ty_path);
+            let field_type = field.column_type_override.unwrap_or_else(|| type_with_arguments(&field.ty_path));
             let is_static = schema_object.static_columns.contains(&field_name);
 
             schema_object.push_field(field_name, field_type, is_static);

--- a/charybdis/Cargo.toml
+++ b/charybdis/Cargo.toml
@@ -22,8 +22,12 @@ serde = { version = "1.0.200", features = ["derive"] }
 colored = "2.1.0"
 bigdecimal = { version = "0.4.3", features = ["serde"] }
 
+
 [features]
 migrate = ["charybdis-migrate"]
 
 [dev-dependencies]
 tokio = "1.42.0"
+strum = { version = "0.26.3", features = ["derive"] }
+serde = "1.0"
+serde_json = "1.0"

--- a/charybdis/README.md
+++ b/charybdis/README.md
@@ -827,3 +827,29 @@ pub struct User {
 So field `organization` will be ignored in all operations and
 default value will be used when deserializing from other data sources.
 It can be used to hold data that is not persisted in database.
+
+## Custom Fields
+
+Any rust type can be used directly in table or UDT definition.
+User must choose a ScyllaDB backing type (such as "TinyInt" or "Text")
+and implement `SerializeValue` and `DeserializeValue` traits:
+
+
+```rust
+#[charybdis_model(...)]
+pub struct User {
+    id: Uuid,
+    #[charybdis(column_type = "Text")]
+    extra_data: CustomField,
+}
+
+impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for CustomField {
+    ...
+}
+
+impl SerializeValue for CustomField {
+    ...
+}
+```
+
+See `custom_field.rs` integration test for examples using int and text encoding.

--- a/charybdis/tests/integrations/custom_fields.rs
+++ b/charybdis/tests/integrations/custom_fields.rs
@@ -1,0 +1,107 @@
+use charybdis::scylla::deserialize::DeserializeValue;
+use charybdis::scylla::frame::response::result::ColumnType;
+use charybdis::scylla::SerializeValue;
+use charybdis::types::Text;
+
+#[derive(Debug, Default, Clone, PartialEq, strum::FromRepr)]
+#[repr(i8)]
+pub enum AddressTypeCustomField {
+    #[default]
+    HomeAddress = 0,
+    WorkAddress = 1,
+}
+
+#[derive(Debug)]
+struct AddressTypeCustomDeserializeErr(i8);
+impl std::fmt::Display for AddressTypeCustomDeserializeErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "AddressTypeCustomDeserializeErr({})", self.0)
+    }
+}
+impl std::error::Error for AddressTypeCustomDeserializeErr {}
+
+impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for AddressTypeCustomField {
+    fn type_check(
+        typ: &scylla::frame::response::result::ColumnType,
+    ) -> std::result::Result<(), scylla::deserialize::TypeCheckError> {
+        <i8 as DeserializeValue<'frame, 'metadata>>::type_check(typ)
+    }
+
+    fn deserialize(
+        typ: &'metadata ColumnType<'metadata>,
+        v: Option<scylla::deserialize::FrameSlice<'frame>>,
+    ) -> std::result::Result<Self, scylla::deserialize::DeserializationError> {
+        let si8 = <i8 as DeserializeValue<'frame, 'metadata>>::deserialize(typ, v)?;
+        let s = Self::from_repr(si8);
+        s.ok_or_else(|| scylla::deserialize::DeserializationError::new(AddressTypeCustomDeserializeErr(si8)))
+    }
+}
+
+impl SerializeValue for AddressTypeCustomField {
+    fn serialize<'b>(
+        &self,
+        typ: &ColumnType,
+        writer: scylla::serialize::writers::CellWriter<'b>,
+    ) -> Result<scylla::serialize::writers::WrittenCellProof<'b>, scylla::serialize::SerializationError> {
+        let disc = self.clone() as i8;
+
+        let v  = <i8 as SerializeValue>::serialize(&disc, typ, writer)?;
+        Ok(v)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct UserExtraDataCustomField {
+    pub user_tags: Vec<(String, String)>,
+}
+
+impl Default for UserExtraDataCustomField {
+    fn default() -> Self {
+        Self { user_tags: vec![("some_key".to_string(), "some_value".to_string())] }
+    }
+}
+
+#[derive(Debug)]
+struct UserExtraDataDeserializeErr(String);
+impl std::fmt::Display for UserExtraDataDeserializeErr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "UserExtraDataDeserializeErr({})", self.0)
+    }
+}
+impl std::error::Error for UserExtraDataDeserializeErr {}
+
+impl<'frame, 'metadata> DeserializeValue<'frame, 'metadata> for UserExtraDataCustomField {
+    fn type_check(
+        typ: &scylla::frame::response::result::ColumnType,
+    ) -> std::result::Result<(), scylla::deserialize::TypeCheckError> {
+        <Text as DeserializeValue<'frame, 'metadata>>::type_check(typ)
+    }
+
+    fn deserialize(
+        typ: &'metadata ColumnType<'metadata>,
+        v: Option<scylla::deserialize::FrameSlice<'frame>>,
+    ) -> std::result::Result<Self, scylla::deserialize::DeserializationError> {
+        let si8 = <Text as DeserializeValue<'frame, 'metadata>>::deserialize(typ, v)?;
+        serde_json::from_str::<UserExtraDataCustomField>(&si8)
+            .map_err(
+                |_e| scylla::deserialize::DeserializationError::new(
+                        UserExtraDataDeserializeErr(si8)))
+    }
+}
+
+impl SerializeValue for UserExtraDataCustomField {
+    fn serialize<'b>(
+        &self,
+        typ: &ColumnType,
+        writer: scylla::serialize::writers::CellWriter<'b>,
+    ) -> Result<scylla::serialize::writers::WrittenCellProof<'b>, scylla::serialize::SerializationError> {
+
+        let disc = serde_json::to_string(&self)
+            .map_err(|_e| scylla::serialize::SerializationError::new(
+                _e
+            ))?;
+
+        let v  = <Text as SerializeValue>::serialize(&disc, typ, writer)?;
+        Ok(v)
+    }
+}

--- a/charybdis/tests/integrations/main.rs
+++ b/charybdis/tests/integrations/main.rs
@@ -1,3 +1,5 @@
 mod common;
 mod model;
 mod query;
+
+mod custom_fields;

--- a/charybdis/tests/integrations/model.rs
+++ b/charybdis/tests/integrations/model.rs
@@ -1,4 +1,6 @@
 use crate::common::db_session;
+use crate::custom_fields::{AddressTypeCustomField,UserExtraDataCustomField};
+
 use charybdis::batch::ModelBatch;
 use charybdis::errors::CharybdisError;
 use charybdis::model::{BaseModel, Model};
@@ -14,6 +16,8 @@ pub struct Address {
     pub state: Text,
     pub zip: Text,
     pub country: Text,
+    #[charybdis(column_type = "TinyInt")]
+    pub addr_type: AddressTypeCustomField,
 }
 
 #[charybdis_model(
@@ -33,6 +37,8 @@ pub struct User {
     pub bio: Option<Text>,
     pub address: Option<Address>,
     pub is_confirmed: Boolean,
+    #[charybdis(column_type = "Text")]
+    pub user_extra_data: UserExtraDataCustomField,
 }
 
 partial_user!(UpdateUsernameUser, id, username);
@@ -72,8 +78,10 @@ impl User {
                 state: "Illinois".to_string(),
                 zip: "62701".to_string(),
                 country: "USA".to_string(),
+                addr_type: AddressTypeCustomField::WorkAddress,
             }),
             is_confirmed: true,
+            user_extra_data: UserExtraDataCustomField::default()
         }
     }
 }
@@ -83,38 +91,38 @@ async fn user_model_queries() {
     assert_eq!(User::DB_MODEL_NAME, "users");
     assert_eq!(
         User::FIND_ALL_QUERY,
-        "SELECT id, username, password, email, first_name, last_name, bio, address, is_confirmed FROM users"
+        "SELECT id, username, password, email, first_name, last_name, bio, address, is_confirmed, user_extra_data FROM users"
     );
     assert_eq!(
         User::FIND_BY_PRIMARY_KEY_QUERY,
         "SELECT id, username, password, email, \
-         first_name, last_name, bio, address, is_confirmed FROM users WHERE id = ?"
+         first_name, last_name, bio, address, is_confirmed, user_extra_data FROM users WHERE id = ?"
     );
     assert_eq!(
         User::FIND_BY_PARTITION_KEY_QUERY,
         "SELECT id, username, password, email, \
-         first_name, last_name, bio, address, is_confirmed FROM users WHERE id = ?"
+         first_name, last_name, bio, address, is_confirmed, user_extra_data FROM users WHERE id = ?"
     );
     assert_eq!(
         User::FIND_FIRST_BY_PARTITION_KEY_QUERY,
         "SELECT id, username, password, email, \
-         first_name, last_name, bio, address, is_confirmed FROM users WHERE id = ? LIMIT 1"
+         first_name, last_name, bio, address, is_confirmed, user_extra_data FROM users WHERE id = ? LIMIT 1"
     );
     assert_eq!(
         User::INSERT_QUERY,
-        "INSERT INTO users (id, username, password, email, first_name, last_name, bio, address, is_confirmed) \
-         VALUES (:id, :username, :password, :email, :first_name, :last_name, :bio, :address, :is_confirmed)"
+        "INSERT INTO users (id, username, password, email, first_name, last_name, bio, address, is_confirmed, user_extra_data) \
+         VALUES (:id, :username, :password, :email, :first_name, :last_name, :bio, :address, :is_confirmed, :user_extra_data)"
     );
     assert_eq!(
         User::INSERT_IF_NOT_EXIST_QUERY,
-        "INSERT INTO users (id, username, password, email, first_name, last_name, bio, address, is_confirmed) \
-         VALUES (:id, :username, :password, :email, :first_name, :last_name, :bio, :address, :is_confirmed) \
+        "INSERT INTO users (id, username, password, email, first_name, last_name, bio, address, is_confirmed, user_extra_data) \
+         VALUES (:id, :username, :password, :email, :first_name, :last_name, :bio, :address, :is_confirmed, :user_extra_data) \
          IF NOT EXISTS"
     );
     assert_eq!(
         User::UPDATE_QUERY,
         "UPDATE users SET username = :username, password = :password, email = :email, first_name = :first_name, \
-        last_name = :last_name, bio = :bio, address = :address, is_confirmed = :is_confirmed WHERE id = :id"
+        last_name = :last_name, bio = :bio, address = :address, is_confirmed = :is_confirmed, user_extra_data = :user_extra_data WHERE id = :id"
     );
     assert_eq!(User::DELETE_QUERY, "DELETE FROM users WHERE id = ?");
     assert_eq!(User::DELETE_BY_PARTITION_KEY_QUERY, "DELETE FROM users WHERE id = ?");

--- a/charybdis/tests/integrations/query.rs
+++ b/charybdis/tests/integrations/query.rs
@@ -1,4 +1,5 @@
 use crate::common::db_session;
+use crate::custom_fields::AddressTypeCustomField;
 use crate::model::{Post, User};
 use charybdis::batch::ModelBatch;
 use charybdis::errors::CharybdisError;
@@ -27,6 +28,11 @@ async fn model_mutation() {
     assert_eq!(user, new_user);
 
     user.bio = Some("I like beer".to_string());
+    if let Some(ref mut address) = user.address {
+        address.addr_type = AddressTypeCustomField::HomeAddress;
+    } else {panic!("homer should have address")};
+    let tag = ("Second Key".to_string(), "Second Value".to_string());
+    user.user_extra_data.user_tags.push(tag.clone());
 
     user.update().execute(&db_session).await.expect("Failed to update user");
 
@@ -36,6 +42,10 @@ async fn model_mutation() {
         .expect("Failed to find user");
 
     assert_eq!(user.bio, Some("I like beer".to_string()));
+    if let Some(ref address) = user.address {
+        assert_eq!(address.addr_type, AddressTypeCustomField::HomeAddress);
+    } else {panic!("homer should have address")};
+    assert_eq!(user.user_extra_data.user_tags.last().cloned(), Some(tag));
 
     user.delete().execute(&db_session).await.expect("Failed to delete user");
 }

--- a/current_schema.json
+++ b/current_schema.json
@@ -43,7 +43,7 @@
           false
         ],
         [
-          "token",
+          "user_extra_data",
           "text",
           false
         ],
@@ -54,28 +54,28 @@
         ]
       ],
       "field_names": [
-        "password",
-        "last_name",
+        "id",
+        "user_extra_data",
+        "first_name",
         "email",
-        "is_confirmed",
-        "address",
         "username",
         "bio",
-        "id",
-        "token",
-        "first_name"
+        "address",
+        "is_confirmed",
+        "last_name",
+        "password"
       ],
       "types_by_name": {
-        "password": "text",
-        "token": "text",
-        "id": "uuid",
+        "last_name": "text",
+        "user_extra_data": "text",
+        "username": "text",
+        "first_name": "text",
         "address": "address",
         "is_confirmed": "boolean",
+        "password": "text",
         "bio": "text",
-        "last_name": "text",
-        "username": "text",
         "email": "text",
-        "first_name": "text"
+        "id": "uuid"
       },
       "type_name": "",
       "table_name": "",
@@ -91,6 +91,32 @@
           "username"
         ]
       ],
+      "local_secondary_indexes": [],
+      "table_options": null
+    },
+    "extab": {
+      "fields": [
+        [
+          "a",
+          "int",
+          false
+        ]
+      ],
+      "field_names": [
+        "a"
+      ],
+      "types_by_name": {
+        "a": "int"
+      },
+      "type_name": "",
+      "table_name": "",
+      "base_table": "",
+      "partition_keys": [
+        "a"
+      ],
+      "clustering_keys": [],
+      "static_columns": [],
+      "global_secondary_indexes": [],
       "local_secondary_indexes": [],
       "table_options": null
     },
@@ -123,18 +149,18 @@
         ]
       ],
       "field_names": [
-        "category_id",
         "title",
-        "author_id",
         "content",
+        "author_id",
+        "category_id",
         "order_idx"
       ],
       "types_by_name": {
-        "author_id": "uuid",
-        "title": "text",
         "content": "text",
+        "category_id": "uuid",
+        "author_id": "uuid",
         "order_idx": "int",
-        "category_id": "uuid"
+        "title": "text"
       },
       "type_name": "",
       "table_name": "",
@@ -189,21 +215,28 @@
           "country",
           "text",
           false
+        ],
+        [
+          "addr_type",
+          "tinyint",
+          false
         ]
       ],
       "field_names": [
+        "zip",
+        "street",
+        "city",
         "country",
         "state",
-        "street",
-        "zip",
-        "city"
+        "addr_type"
       ],
       "types_by_name": {
         "street": "text",
-        "state": "text",
+        "addr_type": "tinyint",
         "zip": "text",
         "city": "text",
-        "country": "text"
+        "country": "text",
+        "state": "text"
       },
       "type_name": "",
       "table_name": "",
@@ -217,6 +250,108 @@
     }
   },
   "materialized_views": {
+    "posts_author_id_idx_index": {
+      "fields": [
+        [
+          "author_id",
+          "uuid",
+          false
+        ],
+        [
+          "category_id",
+          "uuid",
+          false
+        ],
+        [
+          "idx_token",
+          "bigint",
+          false
+        ],
+        [
+          "order_idx",
+          "int",
+          false
+        ],
+        [
+          "title",
+          "text",
+          false
+        ]
+      ],
+      "field_names": [
+        "author_id",
+        "category_id",
+        "idx_token",
+        "title",
+        "order_idx"
+      ],
+      "types_by_name": {
+        "author_id": "uuid",
+        "idx_token": "bigint",
+        "order_idx": "int",
+        "title": "text",
+        "category_id": "uuid"
+      },
+      "type_name": "",
+      "table_name": "",
+      "base_table": "",
+      "partition_keys": [
+        "author_id"
+      ],
+      "clustering_keys": [
+        "category_id",
+        "idx_token",
+        "order_idx",
+        "title"
+      ],
+      "static_columns": [],
+      "global_secondary_indexes": [],
+      "local_secondary_indexes": [],
+      "table_options": null
+    },
+    "users_username_idx_index": {
+      "fields": [
+        [
+          "id",
+          "uuid",
+          false
+        ],
+        [
+          "idx_token",
+          "bigint",
+          false
+        ],
+        [
+          "username",
+          "text",
+          false
+        ]
+      ],
+      "field_names": [
+        "id",
+        "idx_token",
+        "username"
+      ],
+      "types_by_name": {
+        "idx_token": "bigint",
+        "username": "text",
+        "id": "uuid"
+      },
+      "type_name": "",
+      "table_name": "",
+      "base_table": "",
+      "partition_keys": [
+        "username"
+      ],
+      "clustering_keys": [
+        "id",
+        "idx_token"
+      ],
+      "static_columns": [],
+      "global_secondary_indexes": [],
+      "local_secondary_indexes": [],
+      "table_options": null
+    },
     "posts_category_id_title_idx_index": {
       "fields": [
         [
@@ -236,14 +371,14 @@
         ]
       ],
       "field_names": [
-        "title",
+        "category_id",
         "order_idx",
-        "category_id"
+        "title"
       ],
       "types_by_name": {
         "order_idx": "int",
-        "title": "text",
-        "category_id": "uuid"
+        "category_id": "uuid",
+        "title": "text"
       },
       "type_name": "",
       "table_name": "",
@@ -284,9 +419,9 @@
         "username"
       ],
       "types_by_name": {
-        "id": "uuid",
         "username": "text",
-        "email": "text"
+        "email": "text",
+        "id": "uuid"
       },
       "type_name": "",
       "table_name": "",
@@ -296,108 +431,6 @@
       ],
       "clustering_keys": [
         "id"
-      ],
-      "static_columns": [],
-      "global_secondary_indexes": [],
-      "local_secondary_indexes": [],
-      "table_options": null
-    },
-    "users_username_idx_index": {
-      "fields": [
-        [
-          "id",
-          "uuid",
-          false
-        ],
-        [
-          "idx_token",
-          "bigint",
-          false
-        ],
-        [
-          "username",
-          "text",
-          false
-        ]
-      ],
-      "field_names": [
-        "username",
-        "id",
-        "idx_token"
-      ],
-      "types_by_name": {
-        "idx_token": "bigint",
-        "username": "text",
-        "id": "uuid"
-      },
-      "type_name": "",
-      "table_name": "",
-      "base_table": "",
-      "partition_keys": [
-        "username"
-      ],
-      "clustering_keys": [
-        "id",
-        "idx_token"
-      ],
-      "static_columns": [],
-      "global_secondary_indexes": [],
-      "local_secondary_indexes": [],
-      "table_options": null
-    },
-    "posts_author_id_idx_index": {
-      "fields": [
-        [
-          "author_id",
-          "uuid",
-          false
-        ],
-        [
-          "category_id",
-          "uuid",
-          false
-        ],
-        [
-          "idx_token",
-          "bigint",
-          false
-        ],
-        [
-          "order_idx",
-          "int",
-          false
-        ],
-        [
-          "title",
-          "text",
-          false
-        ]
-      ],
-      "field_names": [
-        "author_id",
-        "order_idx",
-        "title",
-        "idx_token",
-        "category_id"
-      ],
-      "types_by_name": {
-        "category_id": "uuid",
-        "idx_token": "bigint",
-        "title": "text",
-        "order_idx": "int",
-        "author_id": "uuid"
-      },
-      "type_name": "",
-      "table_name": "",
-      "base_table": "",
-      "partition_keys": [
-        "author_id"
-      ],
-      "clustering_keys": [
-        "category_id",
-        "idx_token",
-        "order_idx",
-        "title"
       ],
       "static_columns": [],
       "global_secondary_indexes": [],


### PR DESCRIPTION
adds attribute `    #[charybdis(column_type = "TinyInt")]   ` that overrides detected cql type when in migrations.

So far only works on tables; should add this for UDT too 

closes https://github.com/nodecosmos/charybdis/issues/66 closes https://github.com/nodecosmos/charybdis/issues/68